### PR TITLE
Use cdnjs instead of jsDelivr

### DIFF
--- a/Course_Selection_Main/cal.html
+++ b/Course_Selection_Main/cal.html
@@ -11,8 +11,6 @@
     <meta name="description" content="Stay updated with important EPS events with the interactive Orca News calendar.">
     <link rel="stylesheet" href="careers.css">
     <title>Elgin Park Secondary</title>
-    <!-- FullCalendar CSS -->
-    <link href="https://cdn.jsdelivr.net/npm/fullcalendar@5.11.3/main.min.css" rel="stylesheet">
     <style>
         #calendar-container {
             display: flex;
@@ -75,8 +73,8 @@
         </div>
     </div>
 
-    <script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.15/index.global.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/fullcalendar@5.11.3/locales-all.min.js"></script>
+    <!-- FullCalendar JS -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/fullcalendar/6.1.19/index.global.min.js" integrity="sha512-oVdWXnAvkKCjV7eICa4Hbmdrtg2z8hvsQ6lC1/GRQck7hexUrp7fCJZVU/unJviMXCJdpT1rzUpxVKVKP8IcCA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <script src="cal.js"></script>
     <script src="site_footer.js"></script>
 </body>


### PR DESCRIPTION
We're using Cloudflare (so cdnjs could be faster) and cdnjs packages are vetted vs. jsDelivr.

There is also Subresource Integrity (SRI), which makes the website more secure by checking for tampered code.

Tested, should not cause any issues